### PR TITLE
The camera should be off by default when joining a meeting.

### DIFF
--- a/unity/acsShowcase/Assets/Scenes/SampleScene.unity
+++ b/unity/acsShowcase/Assets/Scenes/SampleScene.unity
@@ -10114,6 +10114,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 66e37921134c0124385f5dd2329ece67, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  meetingManager: {fileID: 1450737122}
+  cameraOnButton: {fileID: 10280569}
+  cameraOffButton: {fileID: 1959775042}
   showMainPanel:
     m_PersistentCalls:
       m_Calls:
@@ -10403,42 +10406,6 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
         m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 10280569}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 1959775042}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1450737122}
-        m_TargetAssemblyTypeName: MeetingManager, Assembly-CSharp
-        m_MethodName: ShareCamera
-        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -33169,8 +33136,7 @@ MonoBehaviour:
   autoLogin: 1
   forceSignInAsGuest: 0
   displayName: 
-  startMuted: 0
-  autoShareLocalVideo: 1
+  autoShareLocalVideo: 0
   playRemoteVideo: 1
   playLocalVideo: 1
   joinedCall:

--- a/unity/acsShowcase/Assets/Scripts/UI/MeetingManager.cs
+++ b/unity/acsShowcase/Assets/Scripts/UI/MeetingManager.cs
@@ -56,12 +56,13 @@ public class MeetingManager : MonoBehaviour
 
     [Header("Meeting Settings")] [SerializeField] [Tooltip("The default meeting locator to use during a Join() request.")]
     private MeetingLocator defaultMeetingLocator = null;
-
-    [SerializeField] [Tooltip("Should a the user join the call muted.")]
-    private bool startMuted = false;
-
+    
     [SerializeField] [Tooltip("The local wecam video automatically be started on joining meeting.")]
     private bool autoShareLocalVideo = false;
+    public bool AutoShareLocalVideo
+    {
+        get => autoShareLocalVideo;
+    }
 
     [SerializeField] [Tooltip("Set if remote videos will be received and played locally.")]
     private bool playRemoteVideo = true;
@@ -398,6 +399,17 @@ public class MeetingManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// set shared camera
+    /// </summary>
+    public void SetShareCamera(bool enable)
+    {
+        if (enable)
+            ShareCamera();
+        else
+            UnshareCamera();
+    }
+    
     /// <summary>
     /// enable camera
     /// </summary>

--- a/unity/acsShowcase/Assets/Scripts/UI/UIVisibilityController.cs
+++ b/unity/acsShowcase/Assets/Scripts/UI/UIVisibilityController.cs
@@ -6,23 +6,31 @@ using UnityEngine.Events;
 
 public class UIVisibilityController : MonoBehaviour
 {
+    [SerializeField] [Tooltip("meeting manager")]
+    private MeetingManager meetingManager = null;
+
+    [SerializeField] [Tooltip("camera on button")]
+    private GameObject cameraOnButton = null;
+
+    [SerializeField] [Tooltip("camera off button")]
+    private GameObject cameraOffButton = null;
 
     [SerializeField] [Tooltip("event raised when showing the main panel")]
     private UnityEvent showMainPanel = new UnityEvent();
-    
+
     [SerializeField] [Tooltip("event raised when hiding the main panel")]
     private UnityEvent hideMainPanel = new UnityEvent();
 
     [SerializeField] [Tooltip("event raised when showing call preview panel")]
     private UnityEvent showCallPreviewPanel = new UnityEvent();
-    
+
     [SerializeField] [Tooltip("event raised when hiding call preview panel")]
     private UnityEvent hideCallPreviewPanel = new UnityEvent();
 
-    
+
     [SerializeField] [Tooltip("event raised when showing in call panel")]
     private UnityEvent showInCallPanel = new UnityEvent();
-    
+
     [SerializeField] [Tooltip("event raised when hiding in call panel")]
     private UnityEvent hideInCallPanel = new UnityEvent();
 
@@ -33,7 +41,7 @@ public class UIVisibilityController : MonoBehaviour
     {
         showMainPanel.Invoke();
     }
-    
+
     /// <summary>
     /// Hide the main panel 
     /// </summary>
@@ -41,12 +49,18 @@ public class UIVisibilityController : MonoBehaviour
     {
         hideMainPanel.Invoke();
     }
-    
+
     /// <summary>
     /// Show the call preview panel
     /// </summary>
     public void ShowCallPreviewPanel()
     {
+        if (meetingManager != null)
+        {
+            if (cameraOnButton != null) cameraOnButton.SetActive(meetingManager.AutoShareLocalVideo);
+            if (cameraOffButton != null) cameraOffButton.SetActive(!meetingManager.AutoShareLocalVideo);
+            meetingManager.SetShareCamera(meetingManager.AutoShareLocalVideo);
+        }
         showCallPreviewPanel.Invoke();
     }
 
@@ -57,7 +71,7 @@ public class UIVisibilityController : MonoBehaviour
     {
         hideCallPreviewPanel.Invoke();
     }
-    
+
     /// <summary>
     /// show the the in-call panel 
     /// </summary>
@@ -73,5 +87,4 @@ public class UIVisibilityController : MonoBehaviour
     {
         hideInCallPanel.Invoke();
     }
-    
 }


### PR DESCRIPTION
Make the camera off by default when joining a meeting. Use the AutoShareLocalVideo setting to configure this.