### PR TITLE
Fix photo bug

### DIFF
--- a/unity/acsShowcase/Assets/Prefabs/Users/MainUser.prefab
+++ b/unity/acsShowcase/Assets/Prefabs/Users/MainUser.prefab
@@ -224,6 +224,7 @@ MonoBehaviour:
   - {fileID: 2800000, guid: 31c743e644772c44492a5100b330ae6d, type: 3}
   - {fileID: 2800000, guid: d2086432f49773e4abf53fc65626554c, type: 3}
   pressableButton: {fileID: 0}
+  defaultIconTexture: {fileID: 2800000, guid: a7c55f177c2da3c48ade207a599e9ddd, type: 3}
 --- !u!114 &7152402777604146220
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity/acsShowcase/Assets/Scripts/Graph/PhotoGetter.cs
+++ b/unity/acsShowcase/Assets/Scripts/Graph/PhotoGetter.cs
@@ -67,6 +67,7 @@ namespace Azure.Communication.Calling.Unity
         #region Private Functions
         private async void UpdateProfilesWorkerAsync()
         {
+            Photo = null;
             byte[] data = null;
             string token = Token;
             if (!string.IsNullOrEmpty(token))
@@ -106,10 +107,6 @@ namespace Azure.Communication.Calling.Unity
                 {
                     Log.Error<PhotoGetter>("Failed load image data into 2D texture.");
                 }
-            }
-            else
-            {
-                Photo = null;
             }
             photoLoaded?.Invoke(args);
             PhotoLoaded?.Invoke(this, args);

--- a/unity/acsShowcase/Assets/Scripts/UI/UserObject.cs
+++ b/unity/acsShowcase/Assets/Scripts/UI/UserObject.cs
@@ -27,7 +27,9 @@ public class UserObject : MonoBehaviour
     private List<Texture2D> presences;
     [SerializeField] [Tooltip("The pressable button of this user object")]
     private PressableButton pressableButton;
-    
+    [SerializeField] [Tooltip("The default icon texture")]
+    private Texture defaultIconTexture;
+
     /// <summary>
     /// list of background color 
     /// </summary>
@@ -98,11 +100,6 @@ public class UserObject : MonoBehaviour
     /// </summary>
     private PresenceAvailability presenceAvail;
     
-    
-    /// <summary>
-    /// default icon texture 
-    /// </summary>
-    private Texture defaultIconTexture;
 
     /// <summary>
     /// user presence 
@@ -127,14 +124,6 @@ public class UserObject : MonoBehaviour
     /// event fired when selecting a particiant for a one to one call
     /// </summary>
     public static event Action<UserObject> OnSelectedParticipantCall;
-
-    /// <summary>
-    /// Start 
-    /// </summary>
-    void Start()
-    {
-        defaultIconTexture = profileIcon.texture;
-    }
 
     /// <summary>
     /// copy user object 


### PR DESCRIPTION
Logging in a second time, the photo should be reset 
Default icon texture changed since setting it to a reference of profile icon texture would cause photo not to properly be reset