### PR TITLE
Add null texture check

### DIFF
--- a/unity/acsShowcase/Assets/Scripts/UI/UserObject.cs
+++ b/unity/acsShowcase/Assets/Scripts/UI/UserObject.cs
@@ -135,8 +135,8 @@ public class UserObject : MonoBehaviour
             userObject.Id, 
             userObject.Email, 
             userObject.UserObjectPageType, 
-            userObject.DisplayName, 
-            (Texture2D)userObject.profileIcon.texture, 
+            userObject.DisplayName,
+            (userObject.profileIcon.texture == null) ? null : (Texture2D)userObject.profileIcon.texture,
             userObject.presenceAvail);
     }
 


### PR DESCRIPTION
Adds a check for null textures to avoid the possibility of a casting error. 